### PR TITLE
Fix cinder slow mounts

### DIFF
--- a/roles/deploy_jhub/files/cinder-kube-storage.yaml
+++ b/roles/deploy_jhub/files/cinder-kube-storage.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   name: cinder-storage
-provisioner: kubernetes.io/cinder
+provisioner: cinder.csi.openstack.org
+reclaimPolicy: Retain
 parameters:
   availability: ceph

--- a/roles/k8s_cluster/tasks/deploy_magnum_cluster.yml
+++ b/roles/k8s_cluster/tasks/deploy_magnum_cluster.yml
@@ -28,6 +28,8 @@
       kube_dashboard_enabled: false
       auto_healing_enable: true
       auto_scaling_enabled: true
+      cloud_provider_enabled: true # required for cinder_csi
+      cinder_csi_enabled: true
       master_lb_floating_ip_enabled: true
       max_node_count: "{{ max_worker_nodes }}"
       container_infra_prefix: "{{ mirror_url }}"


### PR DESCRIPTION
This fixes slow mounts in two commits:
- Use the new CSI plugin as it mounts in around 5 seconds instead of 120+ seconds
- Add a workaround whilst the fix I submitted upstream is backported (https://review.opendev.org/c/openstack/magnum/+/782527) for GPU instances not mounting cinder volumes.

See individual commits for more details